### PR TITLE
Server tweaks

### DIFF
--- a/KLFClient/KLFClient.csproj
+++ b/KLFClient/KLFClient.csproj
@@ -10,15 +10,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>KLFClient</RootNamespace>
     <AssemblyName>KLFClient</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -27,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>True</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/KLFServer/KLFServer.csproj
+++ b/KLFServer/KLFServer.csproj
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>KLFServer</RootNamespace>
     <AssemblyName>KLFServer</AssemblyName>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/KLFServer/Server.cs
+++ b/KLFServer/Server.cs
@@ -19,6 +19,7 @@ namespace KLFServer
 		public const String MAX_CLIENTS_LABEL = "maxClients";
 		public const String JOIN_MESSAGE_LABEL = "joinMessage";
 		public const String UPDATE_INTERVAL_LABEL = "updateInterval";
+		public const String NO_PROMPT = "noPrompt";
 
 		public const bool SEND_UPDATES_TO_SENDER = false;
 
@@ -29,6 +30,7 @@ namespace KLFServer
 		public int maxClients = 32;
 		public int updateInterval = 500;
 		public int numClients;
+		public bool noPrompt = false;
 
 		public Thread listenThread;
 		public TcpListener tcpListener;
@@ -678,6 +680,10 @@ namespace KLFServer
 							if (int.TryParse(line, out new_val) && new_val >= MIN_UPDATE_INTERVAL && new_val <= MAX_UPDATE_INTERVAL)
 								updateInterval = new_val;
 						}
+						else if (label == NO_PROMPT)
+						{
+							bool.TryParse (line, out noPrompt);
+						}
 
 					}
 
@@ -715,6 +721,8 @@ namespace KLFServer
 			writer.WriteLine(UPDATE_INTERVAL_LABEL);
 			writer.WriteLine(updateInterval);
 
+			writer.WriteLine(NO_PROMPT);
+			writer.WriteLine(noPrompt);
 			writer.Close();
 		}
 	}

--- a/KLFServer/Server.cs
+++ b/KLFServer/Server.cs
@@ -53,7 +53,7 @@ namespace KLFServer
 		{
 			stopwatch.Start();
 
-			Console.WriteLine("Hosting server on port " + port + "...");
+			consoleWriteLine("Hosting server on port " + port + "...");
 
 			clients = new ServerClient[maxClients];
 			for (int i = 0; i < clients.Length; i++)
@@ -76,10 +76,10 @@ namespace KLFServer
 			{
 				if (UPnP.NAT.Discover())
 				{
-					Console.WriteLine("NAT Firewall discovered! Users won't be able to connect unless port "+port+" is forwarded.");
-					Console.WriteLine("External IP: " + UPnP.NAT.GetExternalIP().ToString());
+					consoleWriteLine("NAT Firewall discovered! Users won't be able to connect unless port "+port+" is forwarded.");
+					consoleWriteLine("External IP: " + UPnP.NAT.GetExternalIP().ToString());
 					UPnP.NAT.ForwardPort(port, ProtocolType.Tcp, "KLF (TCP)");
-					Console.WriteLine("Forwarded port "+port+" with UPnP");
+					consoleWriteLine("Forwarded port "+port+" with UPnP");
 					upnp_enabled = true;
 				}
 			}
@@ -88,8 +88,8 @@ namespace KLFServer
 				//Console.WriteLine(e);
 			}
 
-			Console.WriteLine("Commands:");
-			Console.WriteLine("/quit - quit");
+			consoleWriteLine("Commands:");
+			consoleWriteLine("/quit - quit");
 
 			while (true)
 			{
@@ -162,7 +162,7 @@ namespace KLFServer
 
 			clients = null;
 
-			Console.WriteLine("Server session ended.");
+			consoleWriteLine("Server session ended.");
 
 			stopwatch.Stop();
 		}
@@ -170,7 +170,7 @@ namespace KLFServer
 		private void listenForClients()
 		{
 
-			Console.WriteLine("Listening for clients...");
+			consoleWriteLine("Listening for clients...");
 			tcpListener.Start(4);
 
 			while (true)
@@ -197,7 +197,7 @@ namespace KLFServer
 					if (addClient(client))
 					{
 						//Send a handshake to the client
-						Console.WriteLine("Accepted client. Handshaking...");
+						consoleWriteLine("Accepted client. Handshaking...");
 						sendHandshakeMessage(client);
 
 						//Send the join message to the client
@@ -210,7 +210,7 @@ namespace KLFServer
 					else
 					{
 						//Client array is full
-						Console.WriteLine("Client attempted to connect, but server is full.");
+						consoleWriteLine("Client attempted to connect, but server is full.");
 						sendHandshakeRefusalMessage(client, "Server is currently full");
 						client.Close();
 					}
@@ -221,8 +221,8 @@ namespace KLFServer
 				if (client == null)
 				{
 					//There was an error accepting the client
-					Console.WriteLine("Error accepting client: ");
-					Console.WriteLine(error_message);
+					consoleWriteLine("Error accepting client: ");
+					consoleWriteLine(error_message);
 				}
 
 			}
@@ -267,7 +267,7 @@ namespace KLFServer
 			if (clients[client_index].receivedHandshake)
 			{
 
-				Console.WriteLine("Client #" + client_index + " " + clients[client_index].username + " has disconnected.");
+				consoleWriteLine("Client #" + client_index + " " + clients[client_index].username + " has disconnected.");
 
 				StringBuilder sb = new StringBuilder();
 
@@ -294,7 +294,7 @@ namespace KLFServer
 			}
 			else
 			{
-				Console.WriteLine("Client failed to handshake successfully.");
+				consoleWriteLine("Client failed to handshake successfully.");
 			}
 
 			sendServerSettings();
@@ -356,7 +356,7 @@ namespace KLFServer
 
 						clients[client_index].mutex.ReleaseMutex();
 
-						Console.WriteLine(username + " has joined the server using client version "+version);
+						consoleWriteLine(username + " has joined the server using client version "+version);
 
 						//Build join message
 						sb.Clear();
@@ -444,7 +444,7 @@ namespace KLFServer
 						String full_message = sb.ToString();
 
 						//Console.SetCursorPosition(0, Console.CursorTop);
-						Console.WriteLine(full_message);
+						consoleWriteLine(full_message);
 
 						//Send the update to all other clients
 						for (int i = 0; i < clients.Length; i++)
@@ -724,6 +724,11 @@ namespace KLFServer
 			writer.WriteLine(NO_PROMPT);
 			writer.WriteLine(noPrompt);
 			writer.Close();
+		}
+
+		public void consoleWriteLine(string text) {
+			string timestamp = "[" + DateTime.Now.ToString ("HH:mm:ss") + "] ";
+			Console.WriteLine (timestamp + text);
 		}
 	}
 }

--- a/KLFServer/ServerMain.cs
+++ b/KLFServer/ServerMain.cs
@@ -57,7 +57,13 @@ namespace KLFServer
 				Console.WriteLine("Enter P to change port, M to change max clients, J to change join message");
 				Console.WriteLine("Enter U to change update interval, Enter H to begin hosting, Q to quit");
 
-				String in_string = Console.ReadLine().ToLower();
+				String in_string;
+				if (server.noPrompt) { // Auto-starting the server if so defined in the config.
+					in_string = "h";
+				}
+				else {
+					in_string = Console.ReadLine().ToLower();
+				}
 
 				if (in_string == "q")
 				{


### PR DESCRIPTION
This pull request has three commits. Please feel free to disagree with any changes I've made, after all it's your project. 

**Commit 1, 3c60769**, _Target framework changed to mono_
Currently you're releasing three packages (Plugin+Client MS .NET4, Server MS .NET4 and Client+Server Mono .NET4). Is there any particular reason not to shift completely to Mono to reduce workload when releasing new builds? Your choice, naturally. Main reason for me to change it was though that I only have Mono SDK installed.

**Commit 2, 18e2964**, _No initial prompt mode added to config and server logic_
By defining noPrompt = True in the config, the server skips the initial prompt where user can configure the server parameters. This allows the server to be restarted automatically without user interaction in case of crash. I did not make this option configurable through the menu prompt though. Only through the config file.

**Commit 3, bbc1ab6**, _Console timestamps for server output_
Adds a new function _consoleWriteLine_ which does the same thing as _Console.WriteLine_, but adds a timestamp in front of the text. Also replaced all old outputs to use the new one so that all text outputted has timestamps. This could be possibly implemented on client side too. Timestamps are in localtime.

Comments are welcome, I can also improve the patches if you wish something changed.

Best regards,
voneiden
